### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ requestID: 67890-fghij
 typescript
 openai`
 
+<a href="https://glama.ai/mcp/servers/36hxinm405"><img width="380" height="200" src="https://glama.ai/mcp/servers/36hxinm405/badge" alt="Postman Tool Generation Server MCP server" /></a>
+
 ## Features
 
 - Generate TypeScript/JavaScript code from Postman collections


### PR DESCRIPTION
This PR adds a badge for the [Postman Tool Generation MCP Server](https://glama.ai/mcp/servers/36hxinm405) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/36hxinm405"><img width="380" height="200" src="https://glama.ai/mcp/servers/36hxinm405/badge" alt="Postman Tool Generation Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.